### PR TITLE
Assorted improvements

### DIFF
--- a/dist/amazon-helpers.js
+++ b/dist/amazon-helpers.js
@@ -50,7 +50,7 @@ var helpers = {
 
     getIdentByUrl: function getIdentByUrl(url) {
 
-        var URLREGEX = /https?:\/\/(www\.)?(.*)amazon\.([a-z\.]{2,5})\/(.*)\/?(?:dp|o|gp|-)\/(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))/;
+        var URLREGEX = /https?:\/\/(www\.)?(.*)amazon\.([a-z\.]{2,6})\/(.*)\/?(?:dp|o|gp|-)\/(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))/;
         var ident = typeof url === 'string' && url.match(URLREGEX);
 
         if (ident) {

--- a/dist/amazon-helpers.js
+++ b/dist/amazon-helpers.js
@@ -45,7 +45,9 @@ var helpers = {
     },
 
     getSecureProductUrl: function getSecureProductUrl(urlOrAsin, tld) {
-        return helpers.getProductUrl(urlOrAsin, tld).replace(/^http:/, 'https:');
+        var url = helpers.getProductUrl(urlOrAsin, tld);
+        if (url === undefined) return;
+        return url.replace(/^http:/, 'https:');
     },
 
     getIdentByUrl: function getIdentByUrl(url) {

--- a/dist/amazon-helpers.js
+++ b/dist/amazon-helpers.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*! amazon-helpers by Manuel Bieh
 * Tiny helper library to extract an ASIN/ISBN number from an Amazon URL or create a (optionally localized) Amazon URL out of an ASIN/ISBN.
 * 
@@ -8,13 +6,15 @@
 * @license MIT
 **/
 
+'use strict';
+
 var helpers = {
 
     getIdent: function getIdent(urlOrAsin) {
 
         if (typeof urlOrAsin === 'string' && (urlOrAsin.length === 10 // ASIN
-         || urlOrAsin.length === 13 // ISBN
-        ) && !!urlOrAsin.match(/^([a-zA-Z0-9]*)$/) === true) {
+         || urlOrAsin.length === 13) // ISBN
+         && !!urlOrAsin.match(/^([a-zA-Z0-9]*)$/) === true) {
 
             return urlOrAsin;
         }
@@ -36,8 +36,8 @@ var helpers = {
         }
 
         if (typeof urlOrAsin === 'string' && (urlOrAsin.length === 10 // ASIN
-         || urlOrAsin.length === 13 // ISBN
-        ) && !!urlOrAsin.match(/^([a-zA-Z0-9]*)$/) === true) {
+         || urlOrAsin.length === 13) // ISBN
+         && !!urlOrAsin.match(/^([a-zA-Z0-9]*)$/) === true) {
 
             tld = tld || 'com';
             return 'http://www.amazon.' + tld + '/dp/' + urlOrAsin;

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,23 @@ You can specify a TLD as second argument to convert your URL to another country
 
 - - -
 
+### .getSecureProductUrl(urlOrAsin[, tld])
+
+Like `.getProductUrl`, but returns `https://` instead of `http://`.
+
+`amazonHelpers.getProductUrl('B000MTST70')`
+
+=> `https://www.amazon.com/dp/B000MTST70`
+
+You can specify a TLD as second argument to convert your URL to another country
+`amazonHelpers.getSecureProductUrl('http://www.amazon.com/dp/B000MTST70', 'co.uk')`
+
+=> `https://www.amazon.co.uk/dp/B000MTST70`
+
+**Attention:** The library does not check if the product exists in the given TLD!
+
+- - -
+
 ### .getIdentByUrl(urlOrAsin)
 
 `amazonHelpers.getIdentByUrl('http://amazon.com/gp/product/B00L3KNWBU')`

--- a/src/amazon-helpers.js
+++ b/src/amazon-helpers.js
@@ -55,7 +55,9 @@ let helpers = {
     },
 
     getSecureProductUrl: (urlOrAsin, tld) => {
-        return helpers.getProductUrl(urlOrAsin, tld).replace(/^http:/,'https:');
+        let url = helpers.getProductUrl(urlOrAsin, tld)
+        if (url === undefined) return
+        return url.replace(/^http:/,'https:');
     },
 
     getIdentByUrl: (url) => {

--- a/src/amazon-helpers.js
+++ b/src/amazon-helpers.js
@@ -60,7 +60,7 @@ let helpers = {
 
     getIdentByUrl: (url) => {
 
-        const URLREGEX = /https?:\/\/(www\.)?(.*)amazon\.([a-z\.]{2,5})\/(.*)\/?(?:dp|o|gp|-)\/(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))/;
+        const URLREGEX = /https?:\/\/(www\.)?(.*)amazon\.([a-z\.]{2,6})\/(.*)\/?(?:dp|o|gp|-)\/(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))/;
         let ident = typeof url === 'string' && url.match(URLREGEX);
 
         if(ident) {

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,15 @@ describe('amazonHelpers', function() {
 
         });
 
+        it('should return undefined for non-Amazon URLs', function () {
+
+            assert.equal(
+                amazonHelpers.getSecureProductUrl('http://example.com/foo'),
+                undefined
+            );
+
+        });
+
     });
 
     describe('#getIdentByUrl()', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -69,6 +69,11 @@ describe('amazonHelpers', function() {
             );
 
             assert.equal(
+                amazonHelpers.getProductUrl('https://www.amazon.com.br/Amazon-53-000471-Adaptador-de-tomada/dp/B012ELKC28?pd_rd_wg=H80Sz&pd_rd_r=cd3ae90a-b15b-47f1-8ecb-bf6e411043a7&pd_rd_w=d87wN&ref_=pd_gw_ri&pf_rd_r=CHZDTR4ESF6GJD4MQKKA&pf_rd_p=bd217df5-79b4-5bf6-a295-379173023db6'),
+                'http://www.amazon.com.br/dp/B012ELKC28'
+            );
+
+            assert.equal(
                 amazonHelpers.getProductUrl('B002E2LO5M'),
                 'http://www.amazon.com/dp/B002E2LO5M'
             );


### PR DESCRIPTION
Fix `getSecureProductUrl()`, document it, and fix regex to recognize `.com.br`. For some reason babel also decided to rearrange a few parentheses, so I let it. I can split these out if you would like, but it was easier to put it all in one PR.